### PR TITLE
Refactor to remove action layout from DataLayer and use block instead

### DIFF
--- a/Block/Data/Category.php
+++ b/Block/Data/Category.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Blocks feeding datalayer
+ *
+ * @category  MagePal
+ * @package   MagePal\GoogleTagManager
+ * @author    Pascal Noisette <netpascal0123@aol.com>
+ * @copyright 2017
+ */
+namespace MagePal\GoogleTagManager\Block\Data;
+
+
+/**
+ * Block : Category for catalog category view page
+ *
+ * @package MagePal\GoogleTagManager
+ * @class   Category
+ */
+class Category extends \Magento\Framework\View\Element\Template
+{
+    
+    /**
+     * Core registry
+     *
+     * @var \Magento\Framework\Registry
+     */
+    protected $_coreRegistry = null;
+
+    /**
+     * @param \Magento\Framework\View\Element\Template\Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Framework\View\Element\Template\Context $context,
+        \Magento\Framework\Registry $registry,
+        array $data = []
+    ) {
+        $this->_coreRegistry = $registry;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * Retrieve current category model object
+     *
+     * @return \Magento\Catalog\Model\Category
+     */
+    public function getCurrentCategory()
+    {
+        if (!$this->hasData('current_category')) {
+            $this->setData('current_category', $this->_coreRegistry->registry('current_category'));
+        }
+        return $this->getData('current_category');
+    }
+
+    /**
+     * Add category data to datalayer
+     *
+     * @return $this
+     */
+    function _prepareLayout()
+    {
+        /** @var $tm \MagePal\GoogleTagManager\Block\Tm */
+        $tm = $this->getParentBlock();
+
+        /** @var $product \Magento\Catalog\Api\Data\ProductInterface */ 
+        $category = $this->getCurrentCategory();
+
+        $tm->addVariable(
+            'list', 
+            'category'
+        );
+
+        $tm->addVariable(
+            'category', 
+            [
+                'id' => $category->getId(),
+                'name' => $category->getName()
+            ]
+        );
+    }
+}

--- a/Block/Data/Product.php
+++ b/Block/Data/Product.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Blocks feeding datalayer
+ *
+ * @category  MagePal
+ * @package   MagePal\GoogleTagManager
+ * @author    Pascal Noisette <netpascal0123@aol.com>
+ * @copyright 2017
+ */
+namespace MagePal\GoogleTagManager\Block\Data;
+
+
+/**
+ * Block : Product for catalog product view page
+ *
+ * @package MagePal\GoogleTagManager
+ * @class   Product
+ */
+class Product extends \Magento\Catalog\Block\Product\AbstractProduct
+{
+    /**
+     * Add product data to datalayer
+     *
+     * @return $this
+     */
+    function _prepareLayout()
+    {
+        /** @var $tm \MagePal\GoogleTagManager\Block\Tm */
+        $tm = $this->getParentBlock();
+
+        /** @var $product \Magento\Catalog\Api\Data\ProductInterface */ 
+        $product = $this->getProduct();
+
+        $tm->addVariable(
+            'list', 
+            'detail'
+        );
+
+        $tm->addVariable(
+            'product', 
+            [
+                'id' => $product->getId(),
+                'sku' => $product->getSku(),
+                'name' => $product->getName(),
+                'price' => $product->getPrice(),
+                'attribute_set_id' => $product->getAttributeSetId()
+            ]
+        );
+    }
+}

--- a/Block/Data/Session.php
+++ b/Block/Data/Session.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Blocks feeding datalayer
+ *
+ * @category  MagePal
+ * @package   MagePal\GoogleTagManager
+ * @author    Pascal Noisette <netpascal0123@aol.com>
+ * @copyright 2017
+ */
+namespace MagePal\GoogleTagManager\Block\Data;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterfaceFactory;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\ViewInterface;
+use Magento\Framework\Module\Manager as ModuleManager;
+use Magento\Framework\View\LayoutInterface;
+
+/**
+ * Block : session for all page
+ *
+ * @package MagePal\GoogleTagManager
+ * @class   Customer
+ */
+abstract class Session extends \Magento\Framework\View\Element\Template
+{
+
+    /**
+     * @var \Magento\Customer\Model\Session
+     */
+    protected $checkoutSession;
+
+    /**
+     * @var \Magento\Customer\Model\Session
+     */
+    protected $customerSession;
+
+    /**
+     * @var \Magento\Framework\View\LayoutInterface
+     */
+    protected $layout;
+
+    /**
+     * @var \Magento\Customer\Api\Data\CustomerInterfaceFactory
+     */
+    protected $customerFactory;
+
+    /**
+     * @var CustomerRepositoryInterface
+     */
+    protected $customerRepository;
+
+    /**
+     * @var \Magento\Framework\App\RequestInterface
+     */
+    protected $request;
+
+    /**
+     * @var \Magento\Framework\Module\Manager
+     */
+    protected $moduleManager;
+
+    /**
+     * @var \Magento\Framework\App\ViewInterface
+     */
+    protected $view;
+    
+
+    /**
+     * Constructor
+     *
+     * @param \Magento\Framework\View\Element\Template\Context $context
+     * @param\Magento\Customer\Helper\Session\CurrentCustomer $currentCustomer
+     * @param array $data
+     *
+     */
+    public function __construct(
+        \Magento\Framework\View\Element\Template\Context $context,
+        CustomerSession $customerSession,
+        CheckoutSession $checkoutSession,
+        LayoutInterface $layout,
+        CustomerInterfaceFactory $customerFactory,
+        CustomerRepositoryInterface $customerRepository,
+        RequestInterface $request,
+        ModuleManager $moduleManager,
+        ViewInterface $view,
+        array $data = []
+    ) {
+        $this->customerSession = $customerSession;
+        $this->checkoutSession = $checkoutSession;
+        $this->layout = $layout;
+        $this->customerFactory = $customerFactory;
+        $this->customerRepository = $customerRepository;
+        $this->request = $request;
+        $this->moduleManager = $moduleManager;
+        $this->view = $view;
+        parent::__construct($context, $data);
+    }
+    
+    /**
+     * Check if page is cachable
+     * 
+     * @return bool
+     */
+    protected function pageIsCachable()
+    {
+        return $this->moduleManager->isEnabled('Magento_PageCache')
+            && !$this->request->isAjax()
+            && $this->view->isLayoutLoaded()
+            && $this->layout->isCacheable();
+    }
+}

--- a/Block/Data/Session/Cart.php
+++ b/Block/Data/Session/Cart.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Blocks feeding datalayer
+ *
+ * @category  MagePal
+ * @package   MagePal\GoogleTagManager
+ * @author    Pascal Noisette <netpascal0123@aol.com>
+ * @copyright 2017
+ */
+namespace MagePal\GoogleTagManager\Block\Data\Session;
+
+
+/**
+ * Block : Customer for all page
+ *
+ * @package MagePal\GoogleTagManager
+ * @class   Customer
+ */
+class Cart extends \MagePal\GoogleTagManager\Block\Data\Session
+{
+
+    /**
+     * Get active quote
+     *
+     * @return Quote
+     */
+    public function getQuote()
+    {
+        return $this->checkoutSession->getQuote();
+    }
+
+    /**
+     * Add product data to datalayer
+     *
+     * @return $this
+     */
+    function _prepareLayout()
+    {
+        /** @var $tm \MagePal\GoogleTagManager\Block\Tm */
+        $tm = $this->getParentBlock();
+
+        if ($this->pageIsCachable()) {
+            $tm->addVariable('cart', ['hasItems'=>false]);
+        } else {
+            $quote = $this->getQuote();
+            $cart = [];
+            
+            $cart['hasItems'] = false;
+    
+            if ($quote->getItemsCount()) {
+                $items = [];
+                // set items
+                foreach($quote->getAllVisibleItems() as $item){
+                    $items[] = [
+                        'sku' => $item->getSku(),
+                        'name' => $item->getName(),
+                        'price' => $item->getPrice(),
+                        'quantity' => $item->getQty(),
+                    ];
+                }
+                
+                if(count($items) > 0){
+                    $cart['hasItems'] = true;
+                    $cart['items'] = $items; 
+                }
+                
+                $cart['total'] = $quote->getGrandTotal();
+                $cart['itemCount'] = $quote->getItemsCount();
+                
+                //set coupon code
+                $coupon = $quote->getCouponCode();
+                
+                $cart['hasCoupons'] = $coupon ? true : false;
+    
+                if($coupon){
+                    $cart['couponCode'] = $coupon;
+                }
+            }
+        
+            $tm->addVariable('cart', $cart);
+        }
+    }
+
+    /**
+     * Format Price
+     *
+     * @return float
+     */
+    public function formatPrice($price){
+        return sprintf('%.2F', $price);
+    }
+}

--- a/Block/Data/Session/Customer.php
+++ b/Block/Data/Session/Customer.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Blocks feeding datalayer
+ *
+ * @category  MagePal
+ * @package   MagePal\GoogleTagManager
+ * @author    Pascal Noisette <netpascal0123@aol.com>
+ * @copyright 2017
+ */
+namespace MagePal\GoogleTagManager\Block\Data\Session;
+
+
+/**
+ * Block : Customer for all page
+ *
+ * @package MagePal\GoogleTagManager
+ * @class   Customer
+ */
+class Customer extends \MagePal\GoogleTagManager\Block\Data\Session
+{
+    /**
+     * Add product data to datalayer
+     *
+     * @return $this
+     */
+    function _prepareLayout()
+    {
+        /** @var $tm \MagePal\GoogleTagManager\Block\Tm */
+        $tm = $this->getParentBlock();
+
+        if ($this->pageIsCachable() || !$this->customerSession->isLoggedIn()) {
+            $tm->addVariable('customer', ['isLoggedIn'=>false]);
+        } else {
+            $tm->addVariable(
+                'customer', [
+                    'isLoggedIn' => true,
+                    'id' => $this->customerSession->getCustomerId(),
+                    'groupId' => $this->customerSession->getCustomerGroupId()
+                ]
+            );
+        }
+    }
+}

--- a/Model/DataLayer.php
+++ b/Model/DataLayer.php
@@ -13,49 +13,16 @@ use Magento\Framework\DataObject;
 class DataLayer extends DataObject {
     
     /**
-     * @var Quote|null
-     */
-    protected $_quote = null;
-    
-    /**
      * Datalayer Variables
      * @var array
      */
     protected $_variables = [];
 
-    /**
-     * Customer session
-     *
-     * @var \Magento\Customer\Model\Session
-     */
-    protected $_customerSession;
-
-    /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
-     */
-    protected $_scopeConfig;
 
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $_context;
-    
-    /**
-     * Core registry
-     *
-     * @var \Magento\Framework\Registry
-     */
-    protected $_coreRegistry = null;
-
-    /**
-     * @var \Magento\Customer\Model\Session
-     */
-    protected $_checkoutSession;
-    
-    /**
-     * @var string
-     */
-    protected $_fullActionName;
 
 
     /**
@@ -63,31 +30,17 @@ class DataLayer extends DataObject {
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Checkout\Model\Session $checkoutSession
-     * @param \Magento\Framework\Registry $registry
      */
     public function __construct(
         \Magento\Framework\App\Action\Context $context, 
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig, 
         \Magento\Customer\Model\Session $customerSession,
-        \Magento\Checkout\Model\Session $checkoutSession,
-        \Magento\Framework\Registry $registry
+        \Magento\Checkout\Model\Session $checkoutSession
     ) {
-        $this->_scopeConfig = $scopeConfig;
-        $this->_customerSession = $customerSession;
         $this->_context = $context;
-        $this->_coreRegistry = $registry;
-        $this->_checkoutSession = $checkoutSession;
         
-        $this->fullActionName = $this->_context->getRequest()->getFullActionName();
-        
-        $this->addVariable('pageType', $this->fullActionName);
+        $this->addVariable('pageType', $this->_context->getRequest()->getFullActionName());
         $this->addVariable('list', 'other');
-        
-        $this->setCustomerDataLayer();
-        $this->setProductDataLayer();
-        $this->setCategoryDataLayer();
-        $this->setCartDataLayer();
-        
     }
 
     /**
@@ -114,137 +67,5 @@ class DataLayer extends DataObject {
         return $this;
     }
 
-    
-    /**
-     * Set category Data Layer
-     */
-    protected function setCategoryDataLayer() {
-        if($this->fullActionName === 'catalog_category_view'
-           && $_category = $this->_coreRegistry->registry('current_category')
-        ) {
-            $category = [
-                'id' => $_category->getId(),
-                'name' => $_category->getName(),
-            ];
-
-            $this->addVariable('category', $category);
-            $this->addVariable('list', 'category');
-        }
-
-        return $this;
-    }
-    
-    
-    /**
-     * Set product Data Layer
-     */
-    protected function setProductDataLayer() {
-        if($this->fullActionName === 'catalog_product_view'
-           && $_product = $this->_coreRegistry->registry('current_product')
-        ) {
-            $this->addVariable('list', 'detail');
-
-            $product = [
-                'id' => $_product->getId(),
-                'sku' => $_product->getSku(),
-                'name' => $_product->getName(),
-            ];
-
-            $this->addVariable('product', $product);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Set Customer Data Layer
-     */
-    protected function setCustomerDataLayer() {
-        $customer = [];
-        if ($this->_customerSession->isLoggedIn()) {
-            $customer['isLoggedIn'] = true;
-            $customer['id'] = $this->_customerSession->getCustomerId();
-            $customer['groupId'] = $this->_customerSession->getCustomerGroupId();
-        } else {
-            $customer['isLoggedIn'] = false;
-        }
-        
-        $this->addVariable('customer', $customer);
-
-        return $this;
-    }
-    
-    
-    /**
-     * Set cart Data Layer
-     */
-    protected function setCartDataLayer() {
-        if($this->fullActionName === 'checkout_index_index'){
-            $this->addVariable('list', 'cart');
-        }
-        
-        $quote = $this->getQuote();
-        $cart = [];
-        
-        $cart['hasItems'] = false;
-
-        if ($quote->getItemsCount()) {
-            $items = [];
-            // set items
-            foreach($quote->getAllVisibleItems() as $item){
-                $items[] = [
-                    'sku' => $item->getSku(),
-                    'name' => $item->getName(),
-                    'price' => $item->getPrice(),
-                    'quantity' => $item->getQty(),
-                ];
-            }
-            
-            if(count($items) > 0){
-                $cart['hasItems'] = true;
-                $cart['items'] = $items; 
-            }
-            
-            $cart['total'] = $quote->getGrandTotal();
-            $cart['itemCount'] = $quote->getItemsCount();
-            
-            
-            //set coupon code
-            $coupon = $quote->getCouponCode();
-            
-            $cart['hasCoupons'] = $coupon ? true : false;
-
-            if($coupon){
-                $cart['couponCode'] = $coupon;
-            }
-        }
-        
-        $this->addVariable('cart', $cart);
-        
-        return $this;
-    }
-    
-    
-    /**
-     * Get active quote
-     *
-     * @return Quote
-     */
-    public function getQuote()
-    {
-        if (null === $this->_quote) {
-            $this->_quote = $this->_checkoutSession->getQuote();
-        }
-        return $this->_quote;
-    }
-    
-    /**
-     * Format Price
-     *
-     * @return float
-     */
-    public function formatPrice($price){
-        return sprintf('%.2F', $price);
-    }
 
 }

--- a/view/frontend/layout/catalog_category_view.xml
+++ b/view/frontend/layout/catalog_category_view.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <referenceBlock name="magepal_gtm_datalayer">
+        <block class="MagePal\GoogleTagManager\Block\Data\Category" name="magepal_googletagmanager_block_category"/>
+    </referenceBlock>
+</page>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <referenceBlock name="magepal_gtm_datalayer">
+        <block class="MagePal\GoogleTagManager\Block\Data\Product" name="magepal_googletagmanager_block_product"/>
+    </referenceBlock>
+</page>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <referenceBlock name="magepal_gtm_datalayer">
+        <action method="addVariable">
+            <argument name="name" xsi:type="string">list</argument>
+            <argument name="value" xsi:type="string">cart</argument>
+        </action>   
+    </referenceBlock>
+</page>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -11,7 +11,10 @@
           <block class="MagePal\GoogleTagManager\Block\GtmCode" name="gtm_iframe" as="gtm_iframe" template="MagePal_GoogleTagManager::iframe.phtml" />
         </referenceContainer>
         <referenceBlock name="head.additional">
-            <block class="MagePal\GoogleTagManager\Block\Tm" name="magepal_gtm_datalayer" as="magepal_gtm_datalayer" template="MagePal_GoogleTagManager::data_layer.phtml" />
+            <block class="MagePal\GoogleTagManager\Block\Tm" name="magepal_gtm_datalayer" as="magepal_gtm_datalayer" template="MagePal_GoogleTagManager::data_layer.phtml">
+                <block class="MagePal\GoogleTagManager\Block\Data\Session\Customer" name="magepal_googletagmanager_block_customer"/>
+                <block class="MagePal\GoogleTagManager\Block\Data\Session\Cart" name="magepal_googletagmanager_block_cart"/>
+            </block>
             <block class="MagePal\GoogleTagManager\Block\GtmCode" name="gtm_js" as="gtm_js" template="MagePal_GoogleTagManager::js.phtml" />
         </referenceBlock>
     </body>


### PR DESCRIPTION
Please considered this refactoring to improve Model\DataLayer source code :
* full action name verification such as `if($this->fullActionName === 'checkout_index_index'){` is a mecanism that is natively handled by layouts files. You do not need to do it.
* a single model class is responsible for several data extraction tasks (customer session, product data, category data...). One class per task is preferable.
* 250 lines long file/6 parameters constructor are hard to read
* MagePal\GoogleTagManager\Block\Tm::addVariable can be called by other block of the layout