### PR TITLE
Avoid Exception on Product Page + Add transaction id currency and payment mode

### DIFF
--- a/Block/Data/Product.php
+++ b/Block/Data/Product.php
@@ -57,20 +57,27 @@ class Product extends \Magento\Catalog\Block\Product\AbstractProduct
         
         /** @var $product \Magento\Catalog\Api\Data\ProductInterface */ 
         $product = $this->getProduct();
-        
+
         if($product) {
 
-            $tm->addVariable(
-                'product',
-                [
-                    'id' => $product->getId(),
-                    'sku' => $product->getSku(),
-                    'name' => $product->getName(),
-                    'price' => $product->getTypeId() == Type::TYPE_SIMPLE ? $tm->formatPrice($product->getPrice()) : $tm->formatPrice($product->getFinalPrice()),
-                    'attribute_set_id' => $product->getAttributeSetId(),
-                    'path' => implode(" > ", $this->getBreadCrumbPath())
-                ]
-            );
+            try {
+                $productId = $product->getId();
+
+                $tm->addVariable(
+                    'product',
+                    [
+                        'id' => $productId,
+                        'sku' => $product->getSku(),
+                        'name' => $product->getName(),
+                        'price' => $product->getTypeId() == Type::TYPE_SIMPLE ? $tm->formatPrice($product->getPrice()) : $tm->formatPrice($product->getFinalPrice()),
+                        'attribute_set_id' => $product->getAttributeSetId(),
+                        'path' => implode(" > ", $this->getBreadCrumbPath())
+                    ]
+                );
+            } catch (Exception $e) {
+                // Do nothing.
+            }
+
         }
         
         return $this;

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -71,7 +71,7 @@ class Order extends DataObject
     /**
      * Render information about specified orders and their items
      *
-     * @return void|string
+     * @return array
      */
     public function getOrderLayer()
     {
@@ -87,6 +87,7 @@ class Order extends DataObject
 
         foreach ($collection as $order) {
 
+            $products = [];
             foreach ($order->getAllVisibleItems() as $item) {
                 $products[] = [
                     'sku' => $item->getSku(),
@@ -105,7 +106,9 @@ class Order extends DataObject
                 'transactionTax' => $this->gtmHelper->formatPrice($order->getTaxAmount()),
                 'transactionCouponCode' => $order->getCouponCode(),
                 'transactionDiscount' => $this->gtmHelper->formatPrice($order->getDiscountAmount()),
-                'transactionProducts' => $products
+                'transactionProducts' => $products,
+                'transactionCurrency' => $order->getBaseCurrencyCode(),
+                'transactionPaymentType' => $order->getPayment()->getMethod(),
             ];
 
 
@@ -113,7 +116,6 @@ class Order extends DataObject
         }
 
         return $result;
-
     }
 
 
@@ -148,5 +150,4 @@ class Order extends DataObject
     {
         return $this->_escaper->escapeJsQuote($data, $quote);
     }
-
 }


### PR DESCRIPTION
Hi,

These are just 2 small changes to avoid an exception in product page in production mode. Adding the try/catch operation avoids having the exception when no product is found (I assume that this layout is called more than once some times).

In the Order confirmation page, I added the currency and payment method.